### PR TITLE
Added TransportEncoding support for body messages

### DIFF
--- a/SendGrid-NET40/SendGrid-NET40.csproj
+++ b/SendGrid-NET40/SendGrid-NET40.csproj
@@ -36,7 +36,7 @@
       <HintPath>..\lib\CodeScales.Http.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.9\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SendGrid-NET40/packages.config
+++ b/SendGrid-NET40/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.9" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
 </packages>

--- a/SendGrid/IMail.cs
+++ b/SendGrid/IMail.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Net.Mail;
+using System.Net.Mime;
 
 namespace SendGrid
 {
@@ -13,28 +14,71 @@ namespace SendGrid
 
         #region Properties
 
+		/// <summary>
+		/// Gets the attachment collection used to store data attached to this e-mail message. 
+		/// </summary>
         string[] Attachments { get; set; }
-        
+
+		/// <summary>
+		/// Gets the address collection that contains the blind carbon copy (BCC) recipients for this e-mail message. 
+		/// </summary>
         MailAddress[] Bcc { get; }
 
+		/// <summary>
+		/// Gets the address collection that contains the carbon copy (CC) recipients for this e-mail message. 
+		/// </summary>
         MailAddress[] Cc { get; }
-        
+
+		/// <summary>
+		/// Gets or sets the from address for this e-mail message. 
+		/// </summary>
         MailAddress From { get; set; }
 
+		/// <summary>
+		/// Gets the IHeader that is used to build the Headers that are transmitted with this e-mail message. 
+		/// </summary>
         IHeader Header { get; set; }
 
+		/// <summary>
+		/// Gets the e-mail headers that are transmitted with this e-mail message. 
+		/// </summary>
         Dictionary<string, string> Headers { get; set; }
 
+		/// <summary>
+		/// The HTML Body for the message.
+		/// </summary>
         string Html { get; set; }
 
+		/// <summary>
+		/// The Transfer encoding to send the HTML body for the message. Used only by SMTP api.
+		/// </summary>
+		TransferEncoding HtmlTransferEncoding { get; set; }
+
+		/// <summary>
+		/// Gets or sets the list of addresses to reply to for the mail message. 
+		/// </summary>
         MailAddress[] ReplyTo { get; set; }
 
         Dictionary<string, MemoryStream> StreamedAttachments { get; set; }
 
+		/// <summary>
+		/// Gets or sets the subject line for this e-mail message. 
+		/// </summary>
         string Subject { get; set; }
 
+		/// <summary>
+		/// The text body for the message.
+		/// </summary>
         string Text { get; set; }
 
+		/// <summary>
+		/// The Transfer encoding to send the text body for the message. Used only by SMTP api.
+		/// </summary>
+		TransferEncoding TextTransferEncoding { get; set; }
+
+		/// <summary>
+		///  Gets the address collection that contains the recipients of this e-mail message.  
+		/// </summary>
         MailAddress[] To { get; set; }
 
         #endregion

--- a/SendGrid/Mail.cs
+++ b/SendGrid/Mail.cs
@@ -102,6 +102,11 @@ namespace SendGrid
         /// </summary>
         public string Html { get; set; }
 
+		/// <summary>
+		/// The Transfer encoding to send the HTML body for the message. Used only by SMTP api.
+		/// </summary>
+		public TransferEncoding HtmlTransferEncoding { get; set; }
+
         /// <summary>
         /// Gets or sets the list of addresses to reply to for the mail message. 
         /// </summary>
@@ -140,6 +145,11 @@ namespace SendGrid
         /// The text body for the message.
         /// </summary>
         public string Text { get; set; }
+
+		/// <summary>
+		/// The Transfer encoding to send the text body for the message. Used only by SMTP api.
+		/// </summary>
+		public TransferEncoding TextTransferEncoding { get; set; }
 
         /// <summary>
         ///  Gets the address collection that contains the recipients of this e-mail message.  
@@ -201,6 +211,8 @@ namespace SendGrid
 
             Text = text;
             Html = html;
+			TextTransferEncoding = TransferEncoding.SevenBit;
+			HtmlTransferEncoding = TransferEncoding.SevenBit;
         }
 
         internal Mail(IHeader header)
@@ -208,6 +220,8 @@ namespace SendGrid
             _message = new MailMessage();
             Header = header;
             Headers = new Dictionary<string, string>();
+			TextTransferEncoding = TransferEncoding.SevenBit;
+			HtmlTransferEncoding = TransferEncoding.SevenBit;
         }
 
         private static Dictionary<string, string> InitializeFilters()
@@ -689,12 +703,14 @@ namespace SendGrid
             if (Text != null)
             {
                 AlternateView plainView = AlternateView.CreateAlternateViewFromString(Text, null, "text/plain");
+				plainView.TransferEncoding = TextTransferEncoding;
                 _message.AlternateViews.Add(plainView);
             }
 
             if (Html != null)
             {
                 AlternateView htmlView = AlternateView.CreateAlternateViewFromString(Html, null, "text/html");
+				htmlView.TransferEncoding = HtmlTransferEncoding;
                 _message.AlternateViews.Add(htmlView);
             }
             

--- a/SendGrid/SendGrid-NET45.csproj
+++ b/SendGrid/SendGrid-NET45.csproj
@@ -40,7 +40,7 @@
       <HintPath>..\lib\CodeScales.Http.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.9\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SendGrid/packages.config
+++ b/SendGrid/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.9" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
 </packages>

--- a/Tests/SendGrid.Tests.csproj
+++ b/Tests/SendGrid.Tests.csproj
@@ -36,19 +36,16 @@
   <ItemGroup>
     <Reference Include="CodeScales.Http, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\SendGridMail\lib\CodeScales.Http.dll</HintPath>
+      <HintPath>..\lib\CodeScales.Http.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.5.10.11092\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.mocks">
-      <HintPath>..\packages\NUnit.2.5.10.11092\lib\nunit.mocks.dll</HintPath>
+      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="pnunit.framework">
-      <HintPath>..\packages\NUnit.2.5.10.11092\lib\pnunit.framework.dll</HintPath>
+      <HintPath>..\packages\pNUnit.2.6.2\lib\pnunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.0.10827" />
-  <package id="NUnit" version="2.5.10.11092" />
+  <package id="Moq" version="4.0.10827" targetFramework="net45" />
+  <package id="NUnit" version="2.6.2" targetFramework="net45" />
+  <package id="pNUnit" version="2.6.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This fix helps to specify the Transport Encoding on body message when sending SMTP emails to SendGrid.

http://support.sendgrid.com/entries/21699742-HTML-Formatting-Issues
