### PR TITLE
Fixes on TransferEncoding and Trimming bug

### DIFF
--- a/Mail.NET45/Events.cs
+++ b/Mail.NET45/Events.cs
@@ -114,6 +114,8 @@ namespace SendGrid
         /// <returns></returns>
         public static List<EventData> GetEvents(string json)
         {
+			json = json.Trim();
+
             // RWM: Deal with v1 and v2 batched Event data.
             if (!json.StartsWith("["))
             {
@@ -126,7 +128,7 @@ namespace SendGrid
                 json += "]";
             }
 
-            return JsonConvert.DeserializeObject<List<EventData>>(json.Trim());
+            return JsonConvert.DeserializeObject<List<EventData>>(json);
         }
 
         /// <summary>
@@ -137,6 +139,8 @@ namespace SendGrid
         /// <returns></returns>
         public static List<T> GetEvents<T>(string json) where T : EventData
         {
+			json = json.Trim();
+
             // RWM: Deal with v1 and v2 batched Event data.
             if (!json.StartsWith("["))
             {
@@ -149,7 +153,7 @@ namespace SendGrid
                 json += "]";
             }
 
-            return JsonConvert.DeserializeObject<List<T>>(json.Trim());
+            return JsonConvert.DeserializeObject<List<T>>(json);
         }
 
     }

--- a/Mail.NET45/Mail.cs
+++ b/Mail.NET45/Mail.cs
@@ -134,7 +134,7 @@ namespace SendGrid
         public string Text { get; set; }
 
 		/// <summary>
-		/// The Transfer encoding to send the text body for the message. Used only by SMTP api.
+		/// The Transfer encoding to send the text body for the message. Used only by SMTP api. Default (Base64)
 		/// </summary>
 		public TransferEncoding TextTransferEncoding { get; set; }
 
@@ -197,8 +197,9 @@ namespace SendGrid
 
             Text = text;
             Html = html;
-			TextTransferEncoding = TransferEncoding.SevenBit;
-			HtmlTransferEncoding = TransferEncoding.SevenBit;
+
+			TextTransferEncoding = TransferEncoding.Base64;
+			HtmlTransferEncoding = TransferEncoding.Base64;
         }
 
         internal Mail(IHeader header)
@@ -206,8 +207,8 @@ namespace SendGrid
             _message = new MailMessage();
             Header = header;
             Headers = new Dictionary<string, string>();
-			TextTransferEncoding = TransferEncoding.SevenBit;
-			HtmlTransferEncoding = TransferEncoding.SevenBit;
+			TextTransferEncoding = TransferEncoding.Base64;
+			HtmlTransferEncoding = TransferEncoding.Base64;
         }
 
         private static Dictionary<string, string> InitializeFilters()
@@ -741,14 +742,14 @@ namespace SendGrid
             if (Text != null)
             {
                 AlternateView plainView = AlternateView.CreateAlternateViewFromString(Text, null, "text/plain");
-				//plainView.TransferEncoding = TextTransferEncoding;
+				plainView.TransferEncoding = TextTransferEncoding;
                 _message.AlternateViews.Add(plainView);
             }
 
             if (Html != null)
             {
                 AlternateView htmlView = AlternateView.CreateAlternateViewFromString(Html, null, "text/html");
-				//htmlView.TransferEncoding = HtmlTransferEncoding;
+				htmlView.TransferEncoding = HtmlTransferEncoding;
                 _message.AlternateViews.Add(htmlView);
             }
             


### PR DESCRIPTION
On the last code, the TransferEncoding was commented out. I uncomment it and leave the default value to be Base64 which is the normal behavior.

The trimming bug on payload for SendGrid was fixed applying a Trim() before the workarounds. Otherwise, the hack was adding and extra closing bracket ']' when the payload ended with spaces and deserialization was failing.

Hope these changes can get updated to Nuget soon.
